### PR TITLE
Fix wrong `Website` key's value in `plugin.json`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
     "Author": "jasonz3157",
     "Version": "0.1.6",
     "Language": "python",
-    "Website": "https://github.com/jasonz3157/Flow.Launcher.Plugin.DateCalculator",
+    "Website": "https://github.com/jasonz3157/Flow.Plugin.DateCalculator",
     "IcoPath": "Images\\app.png",
     "ExecuteFileName": "main.py"
 }


### PR DESCRIPTION
The repository seems to have been renamed since the `Website` key's value in the `plugin.json` file was updated last, so this pr just updates it so that it is correct